### PR TITLE
Changes to get screenshot window sizer work on GNOME 3.16

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -75,7 +75,7 @@ function cycleScreenshotSizes(display, screen, window, binding) {
         window.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
 
     let workArea = window.get_work_area_current_monitor();
-    let outerRect = window.get_outer_rect();
+    let outerRect = window.get_frame_rect();
 
     // Find the nearest 16:9 size for the current window size
     let nearestIndex;
@@ -109,7 +109,7 @@ function cycleScreenshotSizes(display, screen, window, binding) {
 
     window.move_resize_frame(true, newX, newY, newWidth, newHeight);
 
-    let newOuterRect = window.get_outer_rect();
+    let newOuterRect = window.get_frame_rect();
     let message = newOuterRect.width + 'x' + newOuterRect.height;
 
     // The new size might have been constrained by geometry hints (e.g. for
@@ -149,7 +149,7 @@ function enable() {
     Main.wm.addKeybinding('cycle-screenshot-sizes',
                           getSettings(),
                           Meta.KeyBindingFlags.PER_WINDOW | Meta.KeyBindingFlags.REVERSES,
-                          Shell.KeyBindingMode.NORMAL,
+                          Shell.ActionMode.NORMAL,
                           cycleScreenshotSizes);
 }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-   "shell-version": ["3.8", "3.10"],
+   "shell-version": ["3.16"],
    "uuid": "screenshot-window-sizer@hughsie.github.com",
    "name": "Screenshot Window Sizer",
    "description": "Resize windows for GNOME Software screenshots",


### PR DESCRIPTION
This patch does a few things to get the extension working on GNOME 3.16:
1. Bumping the version in metadata.json to be GNOME 3.16
2.  change references of window.get_outer_rect() to window.get_frame_rect(), because the Shell deprecated get_outer_rect()
3. change reference of Shell.KeyBindingMode to Shell.ActionMode because the Shell deprecated KeyBindingMode.
